### PR TITLE
Return updated putvalues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { DocumentClient, ReturnValue } from 'aws-sdk/clients/dynamodb';
+import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 type AttributeNames = Record<string, string>;
 type AttributeValues = Record<string, any>;
@@ -93,11 +93,11 @@ export interface ConditionalOptions {
   attributeNames?: AttributeNames;
   attributeValues?: AttributeValues;
 }
-export interface PutConditionalOptions extends ConditionalOptions {
-  returnValues?: ReturnValue;
+export interface PutOptionalParamters {
+  returnOldValues?: boolean;
 }
 
-export type PutOptions = PutConditionalOptions;
+export type PutOptions = ConditionalOptions & PutOptionalParamters;
 export type UpdateOptions = ConditionalOptions;
 export type DeleteOptions = ConditionalOptions;
 
@@ -292,14 +292,14 @@ export default class DynamoDbDao<DataModel, KeySchema> {
     };
 
     // if the caller supplied returnValues, return them instead:
-    if (options.returnValues) {
+    if (options.returnOldValues) {
       const { Attributes: attributes } = await this.documentClient
         .put({
           ...payload,
-          ReturnValues: options.returnValues,
+          ReturnValues: 'ALL_OLD',
         })
         .promise();
-      return attributes as DataModel;
+      return (attributes ?? {}) as DataModel;
     }
 
     await this.documentClient.put(payload).promise();

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,7 @@ export default class DynamoDbDao<DataModel, KeySchema> {
       ExpressionAttributeValues: options.attributeValues,
     };
 
-    // if the caller supplied returnValues, return them instead:
+    // if the caller set a true returnOldValues, return them instead:
     if (options.returnOldValues) {
       const { Attributes: attributes } = await this.documentClient
         .put({

--- a/test/put.test.ts
+++ b/test/put.test.ts
@@ -91,41 +91,41 @@ test('should allow for a expression attribute names to be provided', async () =>
   return expect(promise).rejects.toThrow('The conditional request failed');
 });
 
-test('returns empty object with returnOldValues upon CREATE', async () => {
+test('returns empty object with returnreturnedPreviousValues upon CREATE', async () => {
   const { dao } = context;
   const createOrUpdate = { id: uuid(), test: uuid() };
   const result = await dao.put(createOrUpdate, {
-    returnOldValues: true,
+    returnreturnedPreviousValues: true,
   });
 
   // assuming a new entry, we should see {}:
   expect(result).toMatchObject({});
 });
 
-test('returns old values with returnOldValues upon UPDATE', async () => {
+test('returns old values with returnreturnedPreviousValues upon UPDATE', async () => {
   const { tableName, dao } = context;
   const id = uuid();
   const getItem = () => ({
     id: id,
     test: uuid(),
   });
-  const old_write = getItem(),
+  const previousWrittenData = getItem(),
     createOrUpdate = getItem();
 
   // put data into dynamodb: after update, we should see this returned:
   await documentClient
     .put({
       TableName: tableName,
-      Item: old_write,
+      Item: previousWrittenData,
     })
     .promise();
 
-  const oldValues = await dao.put(createOrUpdate, {
+  const returnedPreviousValues = await dao.put(createOrUpdate, {
     // pass a boolean to get back pre-UPDATE data:
     returnOldValues: true,
   });
 
-  // the data has been updated from `old_write` to `update`
-  // the function should return old_write's properties:
-  expect(oldValues).toMatchObject(old_write);
+  // the data has been updated from `previousWrittenData` to `createOrUpdate`
+  // the function should return previousWrittenData's properties:
+  expect(returnedPreviousValues).toMatchObject(previousWrittenData);
 });

--- a/test/put.test.ts
+++ b/test/put.test.ts
@@ -91,18 +91,18 @@ test('should allow for a expression attribute names to be provided', async () =>
   return expect(promise).rejects.toThrow('The conditional request failed');
 });
 
-test('returns empty object with returnreturnedPreviousValues upon CREATE', async () => {
+test('returns empty object with returnOldValues upon CREATE', async () => {
   const { dao } = context;
   const createOrUpdate = { id: uuid(), test: uuid() };
   const result = await dao.put(createOrUpdate, {
-    returnreturnedPreviousValues: true,
+    returnOldValues: true,
   });
 
   // assuming a new entry, we should see {}:
   expect(result).toMatchObject({});
 });
 
-test('returns old values with returnreturnedPreviousValues upon UPDATE', async () => {
+test('returns old values with returnOldValues upon UPDATE', async () => {
   const { tableName, dao } = context;
   const id = uuid();
   const getItem = () => ({

--- a/test/put.test.ts
+++ b/test/put.test.ts
@@ -90,3 +90,29 @@ test('should allow for a expression attribute names to be provided', async () =>
 
   return expect(promise).rejects.toThrow('The conditional request failed');
 });
+
+test('should accept new option to get back old values', async () => {
+  const { tableName, dao } = context;
+  const id = uuid();
+  const getItem = () => ({
+    id: id,
+    test: uuid(),
+  });
+  const old_write = getItem();
+  const update = getItem();
+
+  // put data into dynamodb
+  await documentClient
+    .put({
+      TableName: tableName,
+      Item: old_write,
+    })
+    .promise();
+
+  const oldValues = await dao.put(update, {
+    // this will cause a failure, because the condition won't match
+    returnValues: 'ALL_OLD',
+  });
+
+  expect(oldValues).toMatchObject(old_write);
+});


### PR DESCRIPTION
 - Exposing `ReturnValues`-controlling boolean in `DynamoDBDao.put()`
    - This put() options parameter (`returnOldValues`), when sent with TRUE, causes return of a map of the pre-update values
    - This is intended for consumption in audit-logging, but could used to detect any CREATE vs UPDATE on PUT