### PR TITLE
CORE-1836 Optimistic locking with version number

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -579,6 +579,7 @@ test('#generateUpdateParams should increment the version number', () => {
       TableName: options.tableName,
       Key: options.key,
       ReturnValues: 'ALL_NEW',
+      ConditionExpression: '#lockVersion = :expectedlockVersion',
       UpdateExpression:
         'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
       ExpressionAttributeNames: {
@@ -591,6 +592,7 @@ test('#generateUpdateParams should increment the version number', () => {
         ':a0': options.data.a,
         ':a1': options.data.b,
         ':lockVersionInc': 1,
+        ':expectedlockVersion': 1,
       },
     });
   }
@@ -617,6 +619,7 @@ test('#generateUpdateParams should increment the version number even when not su
       ReturnValues: 'ALL_NEW',
       UpdateExpression:
         'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
+      ConditionExpression: 'attribute_not_exists(lockVersion)',
       ExpressionAttributeNames: {
         '#a0': 'a',
         '#a1': 'b',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -579,7 +579,7 @@ test('#generateUpdateParams should increment the version number', () => {
       TableName: options.tableName,
       Key: options.key,
       ReturnValues: 'ALL_NEW',
-      ConditionExpression: '#lockVersion = :expectedlockVersion',
+      ConditionExpression: '#lockVersion = :lockVersion',
       UpdateExpression:
         'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
       ExpressionAttributeNames: {
@@ -592,7 +592,7 @@ test('#generateUpdateParams should increment the version number', () => {
         ':a0': options.data.a,
         ':a1': options.data.b,
         ':lockVersionInc': 1,
-        ':expectedlockVersion': 1,
+        ':lockVersion': 1,
       },
     });
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -559,6 +559,79 @@ test('#generateUpdateParams should generate both update and remove params for do
   }
 });
 
+test('#generateUpdateParams should increment the version number', () => {
+  {
+    const options = {
+      tableName: 'blah2',
+      key: {
+        HashKey: 'abc',
+      },
+      data: {
+        a: 123,
+        b: 'abc',
+        c: undefined,
+        lockVersion: 1,
+      },
+      optimisticLockVersionAttribute: 'lockVersion',
+    };
+
+    expect(generateUpdateParams(options)).toEqual({
+      TableName: options.tableName,
+      Key: options.key,
+      ReturnValues: 'ALL_NEW',
+      UpdateExpression:
+        'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
+      ExpressionAttributeNames: {
+        '#a0': 'a',
+        '#a1': 'b',
+        '#a2': 'c',
+        '#lockVersion': 'lockVersion',
+      },
+      ExpressionAttributeValues: {
+        ':a0': options.data.a,
+        ':a1': options.data.b,
+        ':lockVersionInc': 1,
+      },
+    });
+  }
+});
+
+test('#generateUpdateParams should increment the version number even when not supplied', () => {
+  {
+    const options = {
+      tableName: 'blah3',
+      key: {
+        HashKey: 'abc',
+      },
+      data: {
+        a: 123,
+        b: 'abc',
+        c: undefined,
+      },
+      optimisticLockVersionAttribute: 'lockVersion',
+    };
+
+    expect(generateUpdateParams(options)).toEqual({
+      TableName: options.tableName,
+      Key: options.key,
+      ReturnValues: 'ALL_NEW',
+      UpdateExpression:
+        'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
+      ExpressionAttributeNames: {
+        '#a0': 'a',
+        '#a1': 'b',
+        '#a2': 'c',
+        '#lockVersion': 'lockVersion',
+      },
+      ExpressionAttributeValues: {
+        ':a0': options.data.a,
+        ':a1': options.data.b,
+        ':lockVersionInc': 1,
+      },
+    });
+  }
+});
+
 test(`#queryUntilLimitReached should call #query if "filterExpression" not provided`, async () => {
   const keyConditionExpression = 'id = :id';
   const attributeValues = { id: uuid() };

--- a/test/delete.locking.test.ts
+++ b/test/delete.locking.test.ts
@@ -1,0 +1,95 @@
+import { v4 as uuid } from 'uuid';
+import TestContext from './helpers/TestContext';
+
+let context: TestContext;
+
+beforeAll(async () => {
+  context = await TestContext.setup(true);
+});
+
+afterAll(() => {
+  if (context) {
+    return context.teardown();
+  }
+});
+
+test('should require version number to remove item from the table', async () => {
+  const { dao } = context;
+
+  const key = { id: uuid() };
+  const updateData = { test: uuid(), newField: uuid() };
+
+  // put data into dynamodb, which should set the version number
+  await dao.update(key, updateData);
+  await dao.update(key, { ...updateData, version: 1 });
+
+  // ensure it exists
+  const item = await dao.get(key);
+  expect(item).toEqual({
+    ...key,
+    ...updateData,
+    version: 2,
+  });
+
+  await dao.delete(key, undefined, {
+    version: 2,
+  });
+
+  expect(await dao.get(key)).toBeUndefined();
+});
+
+test('should error when version number is missing when removing item from the table', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+  const updateData = { test: uuid(), newField: uuid() };
+
+  // put data into dynamodb, which should set the version number
+  await dao.update(key, updateData);
+  await dao.update(key, { ...updateData, version: 1 });
+
+  await expect(async () => {
+    await dao.delete(key);
+  }).rejects.toThrow('The conditional request failed');
+});
+
+test('should error when version number is old when removing item from the table', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+  const updateData = { test: uuid(), newField: uuid() };
+
+  // put data into dynamodb, which should set the version number
+  await dao.update(key, updateData);
+  await dao.update(key, { ...updateData, version: 1 });
+
+  await expect(async () => {
+    await dao.delete(key, undefined, {
+      version: 1,
+    });
+  }).rejects.toThrow('The conditional request failed');
+});
+
+test('should not require version number to remove item from the table when ignore flag is set', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+  const updateData = { test: uuid(), newField: uuid() };
+
+  // put data into dynamodb, which should set the version number
+  await dao.update(key, updateData);
+
+  // ensure it exists
+  const item = await dao.get(key);
+  expect(item).toEqual({
+    ...key,
+    ...updateData,
+    version: 1,
+  });
+
+  await dao.delete(key, { ignoreOptimisticLocking: true });
+
+  // ensure it deleted
+  const deletedItem = await dao.get(key);
+  expect(deletedItem).toEqual(undefined);
+});

--- a/test/helpers/TestContext.ts
+++ b/test/helpers/TestContext.ts
@@ -43,7 +43,9 @@ export default class TestContext {
     this.dao = dao;
   }
 
-  static async setup(): Promise<TestContext> {
+  static async setup(
+    useOptimisticLocking: boolean = false
+  ): Promise<TestContext> {
     const tableName = uuid();
     const indexName = uuid();
 
@@ -98,6 +100,7 @@ export default class TestContext {
     const dao = new DynamoDbDao<DataModel, KeySchema>({
       tableName,
       documentClient,
+      optimisticLockingAttribute: useOptimisticLocking ? 'version' : undefined,
     });
 
     return new TestContext(tableName, indexName, dao);

--- a/test/put.locking.test.ts
+++ b/test/put.locking.test.ts
@@ -1,0 +1,146 @@
+import { v4 as uuid } from 'uuid';
+import TestContext, { documentClient } from './helpers/TestContext';
+
+let context: TestContext;
+
+beforeAll(async () => {
+  context = await TestContext.setup(true);
+});
+
+afterAll(() => {
+  if (context) {
+    return context.teardown();
+  }
+});
+
+test('should add version number on first put', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+
+  const input = {
+    ...key,
+    test: uuid(),
+  };
+
+  // put data into dynamodb
+  await dao.put(input);
+
+  // ensure it exists
+  const { Item: item } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(item).toEqual({
+    ...input,
+    version: 1,
+  });
+});
+
+test('should throw error if version number is not supplied on second update', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+
+  const input = {
+    ...key,
+    test: uuid(),
+  };
+
+  // put data into dynamodb
+  await dao.put(input);
+
+  expect(1).toEqual(1);
+
+  // ensure it exists
+  const { Item: item } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(item).toEqual({
+    ...input,
+    version: 1,
+  });
+
+  await expect(async () => {
+    await dao.put({
+      ...key,
+      test: uuid(),
+    });
+  }).rejects.toThrow('The conditional request failed');
+});
+
+test('should allow multiple puts if version number is incremented', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+
+  const input = {
+    ...key,
+    test: uuid(),
+  };
+
+  // put data into dynamodb
+  await dao.put(input);
+  await dao.put({
+    ...input,
+    version: 1,
+  });
+
+  // ensure it exists
+  const { Item: item } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(item).toEqual({
+    ...input,
+    version: 2,
+  });
+});
+
+test('should allow multiple puts if version number is incremented when multiple conditions exist', async () => {
+  const { tableName, dao } = context;
+
+  const key = { id: uuid() };
+
+  const input = {
+    ...key,
+    test: uuid(),
+  };
+
+  // put data into dynamodb
+  await dao.put(input);
+  await dao.put(
+    {
+      ...input,
+      version: 1,
+    },
+    {
+      attributeNames: { '#test': 'test' },
+      attributeValues: { ':test': input.test, ':test2': '2' },
+      conditionExpression: '#test = :test or #test = :test2',
+    }
+  );
+
+  // ensure it exists
+  const { Item: item } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(item).toEqual({
+    ...input,
+    version: 2,
+  });
+});

--- a/test/update.locking.test.ts
+++ b/test/update.locking.test.ts
@@ -1,0 +1,88 @@
+import { v4 as uuid } from 'uuid';
+import TestContext, { documentClient } from './helpers/TestContext';
+
+let context: TestContext;
+
+beforeAll(async () => {
+  context = await TestContext.setup(true);
+});
+
+afterAll(() => {
+  if (context) {
+    return context.teardown();
+  }
+});
+
+let key: any;
+let item: any;
+
+beforeEach(async () => {
+  const { tableName } = context;
+
+  key = { id: uuid() };
+
+  const input = {
+    ...key,
+    test: uuid(),
+  };
+
+  // put data into dynamodb
+  await documentClient
+    .put({
+      TableName: tableName,
+      Item: input,
+    })
+    .promise();
+
+  // ensure it exists
+  const { Item: storedItem } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(storedItem).toEqual(input);
+  item = storedItem;
+});
+
+test('should set the version number to 1 on first update', async () => {
+  const { tableName, dao } = context;
+  const updateData = { test: uuid(), newField: uuid() };
+  await dao.update(key, updateData);
+
+  const { Item: updatedItem } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(updatedItem).toEqual({
+    ...item,
+    ...updateData,
+    version: 1,
+  });
+});
+
+test('should increment the version number by 1 on subsequent updates', async () => {
+  const { tableName, dao } = context;
+  const updateData = { test: uuid(), newField: uuid() };
+  await dao.update(key, updateData);
+  await dao.update(key, updateData);
+  await dao.update(key, updateData);
+
+  const { Item: updatedItem } = await documentClient
+    .get({
+      TableName: tableName,
+      Key: key,
+    })
+    .promise();
+
+  expect(updatedItem).toEqual({
+    ...item,
+    ...updateData,
+    version: 3,
+  });
+});

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,7 +1,6 @@
-import TestContext, { documentClient } from './helpers/TestContext';
 import { v4 as uuid } from 'uuid';
-
 import reservedWords from './fixtures/reservedWords';
+import TestContext, { documentClient } from './helpers/TestContext';
 
 let context: TestContext;
 


### PR DESCRIPTION
Inspired by: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.OptimisticLocking.html

This adds optimistic locking to this library.  In short, it optionally requires (after the first put/update) an item being mutated to include a version number that matches the current version number in the database.  If it does not, it assumes it is trying to mutate a stale item and throws an error.