### PR TITLE
v1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/dynamodb-dao",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "DynamoDB Data Access Object (DAO) helper library",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Didn't get my tag pushed for 1.5.0 before merging, so bumping this to 1.5.1, which should have the remote tag.