### PR TITLE
v1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/dynamodb-dao",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "DynamoDB Data Access Object (DAO) helper library",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
For some reason, the prior 1.5.1 tag was not found with `git describe`.  Not entirely sure what happened.

I did check this commit with `git describe --exact-match --match "v*.*.*"` locally, so thinking this one is good.