### PR TITLE
CORE-1836 Make version default optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,17 @@ available toggles:
 
    Example of Dao constructed with optimistic locking enabled.
 
-   ```
+   ```typescript
    const dao = new DynamoDbDao<DataModel, KeySchema>({
      tableName,
      documentClient,
      {
-       behavior: {
         optimisticLockingAttribute: 'version',
         // If true, the first put or update will create and initialize
         // the 'version' attribute, otherwise it will not create it
         // This allows adopters to choose to adopt at the item level
         // or at the dao level
         autoInitiateLockingAttribute: true, // default: true
-       }
      }
    });
    ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,14 @@ available toggles:
    const dao = new DynamoDbDao<DataModel, KeySchema>({
      tableName,
      documentClient,
-     optimisticLockingAttribute: 'version',
+     {
+       optimisticLockingAttribute: 'version',
+       // If true, the first put or update will create and initialize
+       // the 'version' attribute, otherwise it will not create it
+       // This allows adopters to choose to adopt at the item level
+       // or at the dao level
+       autoInitiateLockingAttribute: true, // default: true
+     }
    });
    ```
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,14 @@ available toggles:
      tableName,
      documentClient,
      {
-       optimisticLockingAttribute: 'version',
-       // If true, the first put or update will create and initialize
-       // the 'version' attribute, otherwise it will not create it
-       // This allows adopters to choose to adopt at the item level
-       // or at the dao level
-       autoInitiateLockingAttribute: true, // default: true
+       behavior: {
+        optimisticLockingAttribute: 'version',
+        // If true, the first put or update will create and initialize
+        // the 'version' attribute, otherwise it will not create it
+        // This allows adopters to choose to adopt at the item level
+        // or at the dao level
+        autoInitiateLockingAttribute: true, // default: true
+       }
      }
    });
    ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const DEFAULT_QUERY_LIMIT = 50;
 export const MAX_BATCH_OPERATIONS = 25;
+export const DEFAULT_LOCK_INCREMENT = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export type DeleteOptions = ConditionalOptions & MutateBehavior;
 export interface DynamoDbDaoInput<T> {
   tableName: string;
   documentClient: DocumentClient;
-  behavior: DynamoDbDaoBehavior<T>;
+  behavior?: DynamoDbDaoBehavior<T>;
 }
 
 export type DynamoDbDaoBehavior<T> = {
@@ -127,11 +127,11 @@ export default class DynamoDbDao<DataModel, KeySchema> {
     let { attributeNames, attributeValues, conditionExpression } = options;
 
     if (
-      this.behavior.optimisticLockingAttribute &&
+      this.behavior?.optimisticLockingAttribute &&
       !options.ignoreOptimisticLocking
     ) {
       const versionAttribute =
-        this.behavior.optimisticLockingAttribute.toString();
+        this.behavior?.optimisticLockingAttribute.toString();
       ({ attributeNames, attributeValues, conditionExpression } =
         buildOptimisticLockOptions({
           versionAttribute,
@@ -160,12 +160,12 @@ export default class DynamoDbDao<DataModel, KeySchema> {
    */
   async put(data: DataModel, options: PutOptions = {}): Promise<DataModel> {
     let { conditionExpression, attributeNames, attributeValues } = options;
-    if (this.behavior.optimisticLockingAttribute) {
+    if (this.behavior?.optimisticLockingAttribute) {
       // Must cast data to avoid tripping the linter, otherwise, it'll complain
       // about expression of type 'string' can't be used to index type 'unknown'
       const dataAsMap = data as DataModelAsMap;
       const versionAttribute =
-        this.behavior.optimisticLockingAttribute.toString();
+        this.behavior?.optimisticLockingAttribute.toString();
 
       if (!options.ignoreOptimisticLocking) {
         ({ conditionExpression, attributeNames, attributeValues } =
@@ -182,7 +182,7 @@ export default class DynamoDbDao<DataModel, KeySchema> {
       // set the default if directed to do so
       if (versionAttribute in data) {
         dataAsMap[versionAttribute] += DEFAULT_LOCK_INCREMENT;
-      } else if (this.behavior.autoInitiateLockingAttribute) {
+      } else if (this.behavior?.autoInitiateLockingAttribute) {
         dataAsMap[versionAttribute] = DEFAULT_LOCK_INCREMENT;
       }
     }
@@ -215,7 +215,7 @@ export default class DynamoDbDao<DataModel, KeySchema> {
       data,
       ...updateOptions,
       optimisticLockVersionAttribute,
-      autoInitiateLockingAttribute: this.behavior.autoInitiateLockingAttribute,
+      autoInitiateLockingAttribute: this.behavior?.autoInitiateLockingAttribute,
     });
 
     const { Attributes: attributes } = await this.documentClient

--- a/src/locking/buildOptimisticLockOptions.ts
+++ b/src/locking/buildOptimisticLockOptions.ts
@@ -11,15 +11,18 @@ export function buildOptimisticLockOptions(
   const { versionAttribute, versionAttributeValue } = options;
   let { conditionExpression, attributeNames, attributeValues } = options;
 
-  const lockExpression = versionAttributeValue
-    ? `#${versionAttribute} = :${versionAttribute}`
+  // 0 can be passed and is valid, so we need to be specific
+  const versionIsSupplied = versionAttributeValue !== undefined;
+
+  const lockExpression = versionIsSupplied
+    ? `(#${versionAttribute} = :${versionAttribute} OR attribute_not_exists(${versionAttribute}))`
     : `attribute_not_exists(${versionAttribute})`;
 
   conditionExpression = conditionExpression
     ? `(${conditionExpression}) AND ${lockExpression}`
     : lockExpression;
 
-  if (versionAttributeValue) {
+  if (versionIsSupplied) {
     attributeNames = {
       ...attributeNames,
       [`#${versionAttribute}`]: versionAttribute,

--- a/src/update/generateUpdateParams.test.ts
+++ b/src/update/generateUpdateParams.test.ts
@@ -190,3 +190,41 @@ test('#generateUpdateParams should not increment the version number when not sup
     });
   }
 });
+
+test('#generateUpdateParams should increment the version number when not supplied if auto-initiate is set', () => {
+  {
+    const options = {
+      tableName: 'blah3',
+      key: {
+        HashKey: 'abc',
+      },
+      data: {
+        a: 123,
+        b: 'abc',
+        c: undefined,
+      },
+      optimisticLockVersionAttribute: 'lockVersion',
+      autoInitiateLockingAttribute: true,
+    };
+
+    expect(generateUpdateParams(options)).toEqual({
+      TableName: options.tableName,
+      Key: options.key,
+      ReturnValues: 'ALL_NEW',
+      UpdateExpression:
+        'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
+      ConditionExpression: 'attribute_not_exists(lockVersion)',
+      ExpressionAttributeNames: {
+        '#a0': 'a',
+        '#a1': 'b',
+        '#a2': 'c',
+        '#lockVersion': 'lockVersion',
+      },
+      ExpressionAttributeValues: {
+        ':a0': options.data.a,
+        ':a1': options.data.b,
+        ':lockVersionInc': 1,
+      },
+    });
+  }
+});

--- a/src/update/generateUpdateParams.test.ts
+++ b/src/update/generateUpdateParams.test.ts
@@ -138,7 +138,8 @@ test('#generateUpdateParams should increment the version number', () => {
       TableName: options.tableName,
       Key: options.key,
       ReturnValues: 'ALL_NEW',
-      ConditionExpression: '#lockVersion = :lockVersion',
+      ConditionExpression:
+        '(#lockVersion = :lockVersion OR attribute_not_exists(lockVersion))',
       UpdateExpression:
         'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
       ExpressionAttributeNames: {
@@ -156,7 +157,7 @@ test('#generateUpdateParams should increment the version number', () => {
     });
   }
 });
-test('#generateUpdateParams should increment the version number even when not supplied', () => {
+test('#generateUpdateParams should not increment the version number when not supplied', () => {
   {
     const options = {
       tableName: 'blah3',
@@ -175,19 +176,16 @@ test('#generateUpdateParams should increment the version number even when not su
       TableName: options.tableName,
       Key: options.key,
       ReturnValues: 'ALL_NEW',
-      UpdateExpression:
-        'add #lockVersion :lockVersionInc set #a0 = :a0, #a1 = :a1 remove #a2',
+      UpdateExpression: 'set #a0 = :a0, #a1 = :a1 remove #a2',
       ConditionExpression: 'attribute_not_exists(lockVersion)',
       ExpressionAttributeNames: {
         '#a0': 'a',
         '#a1': 'b',
         '#a2': 'c',
-        '#lockVersion': 'lockVersion',
       },
       ExpressionAttributeValues: {
         ':a0': options.data.a,
         ':a1': options.data.b,
-        ':lockVersionInc': 1,
       },
     });
   }

--- a/src/update/generateUpdateParams.ts
+++ b/src/update/generateUpdateParams.ts
@@ -42,9 +42,7 @@ export function generateUpdateParams(
 
   if (versionAttribute) {
     const providesVersion = versionAttribute in data;
-    // We'll only increment if the version is passed in.  This allows us to
-    // avoid setting a default version and require the caller to set it
-    // in order to start enforcing the lock
+
     if (providesVersion || autoInitiateLockingAttribute) {
       addExpressions.push(`#${versionAttribute} :${versionAttribute}Inc`);
       expressionAttributeNameMap[`#${versionAttribute}`] = versionAttribute;

--- a/test/delete.locking.test.ts
+++ b/test/delete.locking.test.ts
@@ -3,90 +3,139 @@ import TestContext from './helpers/TestContext';
 
 let context: TestContext;
 
-beforeAll(async () => {
-  context = await TestContext.setup(true);
-});
-
 afterAll(() => {
   if (context) {
     return context.teardown();
   }
 });
 
-test('should require version number to remove item from the table', async () => {
-  const { dao } = context;
-
-  const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid(), version: 1 };
-
-  await dao.update(key, updateData);
-  await dao.update(key, { ...updateData, version: 1 });
-
-  // ensure it exists
-  const item = await dao.get(key);
-  expect(item).toEqual({
-    ...key,
-    ...updateData,
-    version: 2,
-  });
-
-  await dao.delete(key, undefined, {
-    version: 2,
-  });
-
-  expect(await dao.get(key)).toBeUndefined();
-});
-
-test('should error when version number is missing when removing item from the table', async () => {
-  const { dao } = context;
-
-  const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid(), version: 1 };
-
-  // put data into dynamodb, which should set the version number
-  await dao.update(key, updateData);
-  await dao.update(key, { ...updateData, version: 1 });
-
-  await expect(async () => {
-    await dao.delete(key);
-  }).rejects.toThrow('The conditional request failed');
-});
-
-test('should error when version number is old when removing item from the table', async () => {
-  const { dao } = context;
-
-  const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid(), version: 1 };
-
-  await dao.update(key, updateData);
-  await dao.update(key, { ...updateData, version: 1 });
-
-  await expect(async () => {
-    await dao.delete(key, undefined, {
-      version: 1,
+describe.each([true, false])(
+  'delete with locking and auto-initiate %s',
+  (autoInitiateLockingAttribute) => {
+    beforeAll(async () => {
+      context = await TestContext.setup(true, autoInitiateLockingAttribute);
     });
-  }).rejects.toThrow('The conditional request failed');
-});
+    test('should require version number to remove item from the table', async () => {
+      const { dao } = context;
 
-test('should not require version number to remove item from the table when ignore flag is set', async () => {
-  const { dao } = context;
+      const key = { id: uuid() };
+      const updateData = { test: uuid(), newField: uuid(), version: 1 };
 
-  const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid(), version: 1 };
+      await dao.update(key, updateData);
+      await dao.update(key, { ...updateData, version: 1 });
 
-  await dao.update(key, updateData);
+      // ensure it exists
+      const item = await dao.get(key);
+      expect(item).toEqual({
+        ...key,
+        ...updateData,
+        version: 2,
+      });
 
-  // ensure it exists
-  const item = await dao.get(key);
-  expect(item).toEqual({
-    ...key,
-    ...updateData,
-    version: 1,
-  });
+      await dao.delete(key, undefined, {
+        version: 2,
+      });
 
-  await dao.delete(key, { ignoreOptimisticLocking: true });
+      expect(await dao.get(key)).toBeUndefined();
+    });
 
-  // ensure it deleted
-  const deletedItem = await dao.get(key);
-  expect(deletedItem).toEqual(undefined);
-});
+    test('should error when version number is missing when removing item from the table', async () => {
+      const { dao } = context;
+
+      const key = { id: uuid() };
+      const updateData = { test: uuid(), newField: uuid(), version: 1 };
+
+      // put data into dynamodb, which should set the version number
+      await dao.update(key, updateData);
+      await dao.update(key, { ...updateData, version: 1 });
+
+      await expect(async () => {
+        await dao.delete(key);
+      }).rejects.toThrow('The conditional request failed');
+    });
+
+    test('should error when version number is old when removing item from the table', async () => {
+      const { dao } = context;
+
+      const key = { id: uuid() };
+      const updateData = { test: uuid(), newField: uuid(), version: 1 };
+
+      await dao.update(key, updateData);
+      await dao.update(key, { ...updateData, version: 1 });
+
+      await expect(async () => {
+        await dao.delete(key, undefined, {
+          version: 1,
+        });
+      }).rejects.toThrow('The conditional request failed');
+    });
+
+    test('should not require version number to remove item from the table when ignore flag is set', async () => {
+      const { dao } = context;
+
+      const key = { id: uuid() };
+      const updateData = { test: uuid(), newField: uuid(), version: 1 };
+
+      await dao.update(key, updateData);
+
+      // ensure it exists
+      const item = await dao.get(key);
+      expect(item).toEqual({
+        ...key,
+        ...updateData,
+        version: 1,
+      });
+
+      await dao.delete(key, { ignoreOptimisticLocking: true });
+
+      // ensure it deleted
+      const deletedItem = await dao.get(key);
+      expect(deletedItem).toEqual(undefined);
+    });
+
+    if (autoInitiateLockingAttribute) {
+      test('should require version number to remove an auto-initiated item from the table', async () => {
+        const { dao } = context;
+
+        const key = { id: uuid() };
+        const updateData = { test: uuid(), newField: uuid() };
+
+        await dao.update(key, updateData);
+
+        // ensure it exists
+        const item = await dao.get(key);
+        expect(item).toEqual({
+          ...key,
+          ...updateData,
+          version: autoInitiateLockingAttribute ? 1 : undefined,
+        });
+
+        await expect(async () => {
+          await dao.delete(key, undefined);
+        }).rejects.toThrow('The conditional request failed');
+      });
+    } else {
+      test('should not require version number to remove item from the table', async () => {
+        const { dao } = context;
+
+        const key = { id: uuid() };
+        const updateData = { test: uuid(), newField: uuid() };
+
+        await dao.update(key, updateData);
+
+        // ensure it exists
+        const item = await dao.get(key);
+        expect(item).toEqual({
+          ...key,
+          ...updateData,
+          version: autoInitiateLockingAttribute ? 1 : undefined,
+        });
+        await dao.delete(key);
+
+        // ensure it deleted
+        const deletedItem = await dao.get(key);
+        expect(deletedItem).toEqual(undefined);
+      });
+    }
+  }
+);

--- a/test/delete.locking.test.ts
+++ b/test/delete.locking.test.ts
@@ -17,9 +17,8 @@ test('should require version number to remove item from the table', async () => 
   const { dao } = context;
 
   const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid() };
+  const updateData = { test: uuid(), newField: uuid(), version: 1 };
 
-  // put data into dynamodb, which should set the version number
   await dao.update(key, updateData);
   await dao.update(key, { ...updateData, version: 1 });
 
@@ -42,7 +41,7 @@ test('should error when version number is missing when removing item from the ta
   const { dao } = context;
 
   const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid() };
+  const updateData = { test: uuid(), newField: uuid(), version: 1 };
 
   // put data into dynamodb, which should set the version number
   await dao.update(key, updateData);
@@ -57,9 +56,8 @@ test('should error when version number is old when removing item from the table'
   const { dao } = context;
 
   const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid() };
+  const updateData = { test: uuid(), newField: uuid(), version: 1 };
 
-  // put data into dynamodb, which should set the version number
   await dao.update(key, updateData);
   await dao.update(key, { ...updateData, version: 1 });
 
@@ -74,9 +72,8 @@ test('should not require version number to remove item from the table when ignor
   const { dao } = context;
 
   const key = { id: uuid() };
-  const updateData = { test: uuid(), newField: uuid() };
+  const updateData = { test: uuid(), newField: uuid(), version: 1 };
 
-  // put data into dynamodb, which should set the version number
   await dao.update(key, updateData);
 
   // ensure it exists

--- a/test/helpers/TestContext.ts
+++ b/test/helpers/TestContext.ts
@@ -44,7 +44,8 @@ export default class TestContext {
   }
 
   static async setup(
-    useOptimisticLocking: boolean = false
+    useOptimisticLocking: boolean = false,
+    autoInitiateLockingAttribute: boolean = true
   ): Promise<TestContext> {
     const tableName = uuid();
     const indexName = uuid();
@@ -100,7 +101,12 @@ export default class TestContext {
     const dao = new DynamoDbDao<DataModel, KeySchema>({
       tableName,
       documentClient,
-      optimisticLockingAttribute: useOptimisticLocking ? 'version' : undefined,
+      behavior: {
+        optimisticLockingAttribute: useOptimisticLocking
+          ? 'version'
+          : undefined,
+        autoInitiateLockingAttribute,
+      },
     } as DynamoDbDaoInput<DataModel>);
 
     return new TestContext(tableName, indexName, dao);

--- a/test/helpers/TestContext.ts
+++ b/test/helpers/TestContext.ts
@@ -101,12 +101,8 @@ export default class TestContext {
     const dao = new DynamoDbDao<DataModel, KeySchema>({
       tableName,
       documentClient,
-      behavior: {
-        optimisticLockingAttribute: useOptimisticLocking
-          ? 'version'
-          : undefined,
-        autoInitiateLockingAttribute,
-      },
+      optimisticLockingAttribute: useOptimisticLocking ? 'version' : undefined,
+      autoInitiateLockingAttribute,
     } as DynamoDbDaoInput<DataModel>);
 
     return new TestContext(tableName, indexName, dao);

--- a/test/put.locking.test.ts
+++ b/test/put.locking.test.ts
@@ -3,144 +3,161 @@ import TestContext, { documentClient } from './helpers/TestContext';
 
 let context: TestContext;
 
-beforeAll(async () => {
-  context = await TestContext.setup(true);
-});
-
 afterAll(() => {
   if (context) {
     return context.teardown();
   }
 });
 
-test('should add version number on first put', async () => {
-  const { tableName, dao } = context;
-
-  const key = { id: uuid() };
-
-  const input = {
-    ...key,
-    test: uuid(),
-  };
-
-  // put data into dynamodb
-  await dao.put(input);
-
-  // ensure it exists
-  const { Item: item } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
-
-  expect(item).toEqual({
-    ...input,
-    version: 1,
-  });
-});
-
-test('should throw error if version number is not supplied on second update', async () => {
-  const { tableName, dao } = context;
-
-  const key = { id: uuid() };
-
-  const input = {
-    ...key,
-    test: uuid(),
-  };
-
-  // put data into dynamodb
-  await dao.put(input);
-
-  expect(1).toEqual(1);
-
-  // ensure it exists
-  const { Item: item } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
-
-  expect(item).toEqual({
-    ...input,
-    version: 1,
+describe('with auto-initiated version lock', () => {
+  beforeAll(async () => {
+    context = await TestContext.setup(true, true);
   });
 
-  await expect(async () => {
-    await dao.put({
+  test('should add version number on first put', async () => {
+    const { tableName, dao } = context;
+
+    const key = { id: uuid() };
+
+    const input = {
       ...key,
       test: uuid(),
-    });
-  }).rejects.toThrow('The conditional request failed');
-});
+    };
 
-test('should allow multiple puts if version number is incremented', async () => {
-  const { tableName, dao } = context;
+    // put data into dynamodb
+    await dao.put(input);
 
-  const key = { id: uuid() };
+    // ensure it exists
+    const { Item: item } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
 
-  const input = {
-    ...key,
-    test: uuid(),
-  };
-
-  // put data into dynamodb
-  await dao.put(input);
-  await dao.put({
-    ...input,
-    version: 1,
-  });
-
-  // ensure it exists
-  const { Item: item } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
-
-  expect(item).toEqual({
-    ...input,
-    version: 2,
-  });
-});
-
-test('should allow multiple puts if version number is incremented when multiple conditions exist', async () => {
-  const { tableName, dao } = context;
-
-  const key = { id: uuid() };
-
-  const input = {
-    ...key,
-    test: uuid(),
-  };
-
-  // put data into dynamodb
-  await dao.put(input);
-  await dao.put(
-    {
+    expect(item).toEqual({
       ...input,
       version: 1,
-    },
-    {
-      attributeNames: { '#test': 'test' },
-      attributeValues: { ':test': input.test, ':test2': '2' },
-      conditionExpression: '#test = :test or #test = :test2',
-    }
-  );
+    });
+  });
 
-  // ensure it exists
-  const { Item: item } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
+  test('should throw error if version number is not supplied on second update', async () => {
+    const { tableName, dao } = context;
 
-  expect(item).toEqual({
-    ...input,
-    version: 2,
+    const key = { id: uuid() };
+
+    const input = {
+      ...key,
+      test: uuid(),
+      version: 0,
+    };
+
+    // put data into dynamodb
+    await dao.put(input);
+
+    await expect(async () => {
+      await dao.put({
+        ...key,
+        test: uuid(),
+      });
+    }).rejects.toThrow('The conditional request failed');
+  });
+
+  test('should allow multiple puts if version number is incremented', async () => {
+    const { tableName, dao } = context;
+
+    const key = { id: uuid() };
+
+    const input = {
+      ...key,
+      test: uuid(),
+      version: 0,
+    };
+
+    // put data into dynamodb
+    await dao.put(input);
+    await dao.put({
+      ...input,
+      version: 1,
+    });
+
+    const { Item: item } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(item).toEqual({
+      ...input,
+      version: 2,
+    });
+  });
+
+  test('should allow multiple puts if version number is incremented when multiple conditions exist', async () => {
+    const { tableName, dao } = context;
+
+    const key = { id: uuid() };
+
+    const input = {
+      ...key,
+      test: uuid(),
+      version: 0,
+    };
+
+    // put data into dynamodb
+    await dao.put(input);
+    await dao.put(
+      {
+        ...input,
+        version: 1,
+      },
+      {
+        attributeNames: { '#test': 'test' },
+        attributeValues: { ':test': input.test, ':test2': '2' },
+        conditionExpression: '#test = :test or #test = :test2',
+      }
+    );
+
+    // ensure it exists
+    const { Item: item } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(item).toEqual({
+      ...input,
+      version: 2,
+    });
+  });
+});
+
+describe('without auto-initiated version lock', () => {
+  test('should add version number on first put', async () => {
+    const { tableName, dao } = context;
+
+    const key = { id: uuid() };
+
+    const input = {
+      ...key,
+      test: uuid(),
+    };
+
+    // put data into dynamodb
+    await dao.put(input);
+
+    // ensure it exists
+    const { Item: item } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(item).toEqual({
+      ...input,
+    });
   });
 });

--- a/test/put.locking.test.ts
+++ b/test/put.locking.test.ts
@@ -42,7 +42,7 @@ describe('with auto-initiated version lock', () => {
   });
 
   test('should throw error if version number is not supplied on second update', async () => {
-    const { tableName, dao } = context;
+    const { dao } = context;
 
     const key = { id: uuid() };
 

--- a/test/update.locking.test.ts
+++ b/test/update.locking.test.ts
@@ -3,10 +3,6 @@ import TestContext, { documentClient } from './helpers/TestContext';
 
 let context: TestContext;
 
-beforeAll(async () => {
-  context = await TestContext.setup(true);
-});
-
 afterAll(() => {
   if (context) {
     return context.teardown();
@@ -47,78 +43,127 @@ beforeEach(async () => {
   item = storedItem;
 });
 
-test('should set the version number to 1 on first update', async () => {
-  const { tableName, dao } = context;
-  const updateData = { test: uuid(), newField: uuid() };
-  await dao.update(key, updateData);
-
-  const { Item: updatedItem } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
-
-  expect(updatedItem).toEqual({
-    ...item,
-    ...updateData,
-    version: 1,
+describe('with auto-initiated version lock', () => {
+  beforeAll(async () => {
+    context = await TestContext.setup(true, true);
   });
-});
 
-test('should increment the version number by 1 on subsequent updates', async () => {
-  const { tableName, dao } = context;
-  const updateData = { test: uuid(), newField: uuid() };
-  await dao.update(key, updateData);
-  await dao.update(key, { ...updateData, version: 1 });
-  await dao.update(key, { ...updateData, version: 2 });
-
-  const { Item: updatedItem } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
-
-  expect(updatedItem).toEqual({
-    ...item,
-    ...updateData,
-    version: 3,
-  });
-});
-
-test('should error if update does not supply the correct version number', async () => {
-  const { dao } = context;
-  const updateData = { test: uuid(), newField: uuid() };
-  // sets the initial version to 1
-  await dao.update(key, updateData);
-
-  await expect(async () => {
-    // doesn't supply a version, throws error
+  test('should set the version number on first update if not supplied', async () => {
+    const { tableName, dao } = context;
+    const updateData = { test: uuid(), newField: uuid() };
     await dao.update(key, updateData);
-  }).rejects.toThrow('The conditional request failed');
-});
 
-test('should allow update without correct version number if ignore flag is set', async () => {
-  const { tableName, dao } = context;
-  const updateData = { test: uuid(), newField: uuid() };
-  // sets the initial version to 1
-  await dao.update(key, updateData);
-  // Still increments the version
-  await dao.update(key, updateData, {
-    ignoreOptimisticLocking: true,
+    const { Item: updatedItem } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(updatedItem).toEqual({
+      ...item,
+      ...updateData,
+      version: 1,
+    });
   });
 
-  const { Item: updatedItem } = await documentClient
-    .get({
-      TableName: tableName,
-      Key: key,
-    })
-    .promise();
+  test('should set the version number on first update if supplied', async () => {
+    const { tableName, dao } = context;
+    const updateData = { test: uuid(), newField: uuid(), version: 0 };
+    await dao.update(key, updateData);
 
-  expect(updatedItem).toEqual({
-    ...item,
-    ...updateData,
-    version: 2,
+    const { Item: updatedItem } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(updatedItem).toEqual({
+      ...item,
+      ...updateData,
+      version: 1,
+    });
+  });
+
+  test('should increment the version number by 1 on subsequent updates', async () => {
+    const { tableName, dao } = context;
+    const updateData = { test: uuid(), newField: uuid(), version: 0 };
+    await dao.update(key, updateData);
+    await dao.update(key, { ...updateData, version: 1 });
+    await dao.update(key, { ...updateData, version: 2 });
+
+    const { Item: updatedItem } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(updatedItem).toEqual({
+      ...item,
+      ...updateData,
+      version: 3,
+    });
+  });
+
+  test('should error if update does not supply the correct version number', async () => {
+    const { dao } = context;
+    const updateData = { test: uuid(), newField: uuid(), version: 0 };
+    // sets the initial version to 1
+    await dao.update(key, updateData);
+
+    await expect(async () => {
+      // doesn't supply a version, throws error
+      await dao.update(key, { test: 'new', status: 'value' });
+    }).rejects.toThrow('The conditional request failed');
+  });
+
+  test('should allow update without correct version number if ignore flag is set', async () => {
+    const { tableName, dao } = context;
+    const updateData = { test: uuid(), newField: uuid(), version: 0 };
+    // sets the initial version to 1
+    await dao.update(key, updateData);
+    // Still increments the version
+    await dao.update(key, updateData, {
+      ignoreOptimisticLocking: true,
+    });
+
+    const { Item: updatedItem } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(updatedItem).toEqual({
+      ...item,
+      ...updateData,
+      version: 2,
+    });
+  });
+});
+
+describe('without auto-initiated version lock', () => {
+  beforeAll(async () => {
+    context = await TestContext.setup(true, false);
+  });
+
+  test('should not set the version number on first update if not supplied', async () => {
+    const { tableName, dao } = context;
+    const updateData = { test: uuid(), newField: uuid() };
+    await dao.update(key, updateData);
+
+    const { Item: updatedItem } = await documentClient
+      .get({
+        TableName: tableName,
+        Key: key,
+      })
+      .promise();
+
+    expect(updatedItem).toEqual({
+      ...item,
+      ...updateData,
+    });
   });
 });

--- a/test/update.locking.test.ts
+++ b/test/update.locking.test.ts
@@ -43,127 +43,106 @@ beforeEach(async () => {
   item = storedItem;
 });
 
-describe('with auto-initiated version lock', () => {
-  beforeAll(async () => {
-    context = await TestContext.setup(true, true);
-  });
-
-  test('should set the version number on first update if not supplied', async () => {
-    const { tableName, dao } = context;
-    const updateData = { test: uuid(), newField: uuid() };
-    await dao.update(key, updateData);
-
-    const { Item: updatedItem } = await documentClient
-      .get({
-        TableName: tableName,
-        Key: key,
-      })
-      .promise();
-
-    expect(updatedItem).toEqual({
-      ...item,
-      ...updateData,
-      version: 1,
-    });
-  });
-
-  test('should set the version number on first update if supplied', async () => {
-    const { tableName, dao } = context;
-    const updateData = { test: uuid(), newField: uuid(), version: 0 };
-    await dao.update(key, updateData);
-
-    const { Item: updatedItem } = await documentClient
-      .get({
-        TableName: tableName,
-        Key: key,
-      })
-      .promise();
-
-    expect(updatedItem).toEqual({
-      ...item,
-      ...updateData,
-      version: 1,
-    });
-  });
-
-  test('should increment the version number by 1 on subsequent updates', async () => {
-    const { tableName, dao } = context;
-    const updateData = { test: uuid(), newField: uuid(), version: 0 };
-    await dao.update(key, updateData);
-    await dao.update(key, { ...updateData, version: 1 });
-    await dao.update(key, { ...updateData, version: 2 });
-
-    const { Item: updatedItem } = await documentClient
-      .get({
-        TableName: tableName,
-        Key: key,
-      })
-      .promise();
-
-    expect(updatedItem).toEqual({
-      ...item,
-      ...updateData,
-      version: 3,
-    });
-  });
-
-  test('should error if update does not supply the correct version number', async () => {
-    const { dao } = context;
-    const updateData = { test: uuid(), newField: uuid(), version: 0 };
-    // sets the initial version to 1
-    await dao.update(key, updateData);
-
-    await expect(async () => {
-      // doesn't supply a version, throws error
-      await dao.update(key, { test: 'new', status: 'value' });
-    }).rejects.toThrow('The conditional request failed');
-  });
-
-  test('should allow update without correct version number if ignore flag is set', async () => {
-    const { tableName, dao } = context;
-    const updateData = { test: uuid(), newField: uuid(), version: 0 };
-    // sets the initial version to 1
-    await dao.update(key, updateData);
-    // Still increments the version
-    await dao.update(key, updateData, {
-      ignoreOptimisticLocking: true,
+describe.each([true, false])(
+  'update with locking and auto-initiate %s',
+  (autoInitiateLockingAttribute) => {
+    beforeAll(async () => {
+      context = await TestContext.setup(true, autoInitiateLockingAttribute);
     });
 
-    const { Item: updatedItem } = await documentClient
-      .get({
-        TableName: tableName,
-        Key: key,
-      })
-      .promise();
+    test('should set the version number on first update if not supplied', async () => {
+      const { tableName, dao } = context;
+      const updateData = { test: uuid(), newField: uuid() };
+      await dao.update(key, updateData);
 
-    expect(updatedItem).toEqual({
-      ...item,
-      ...updateData,
-      version: 2,
+      const { Item: updatedItem } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
+
+      expect(updatedItem).toEqual({
+        ...item,
+        ...updateData,
+        version: autoInitiateLockingAttribute ? 1 : undefined,
+      });
     });
-  });
-});
 
-describe('without auto-initiated version lock', () => {
-  beforeAll(async () => {
-    context = await TestContext.setup(true, false);
-  });
+    test('should set the version number on first update if supplied', async () => {
+      const { tableName, dao } = context;
+      const updateData = { test: uuid(), newField: uuid(), version: 0 };
+      await dao.update(key, updateData);
 
-  test('should not set the version number on first update if not supplied', async () => {
-    const { tableName, dao } = context;
-    const updateData = { test: uuid(), newField: uuid() };
-    await dao.update(key, updateData);
+      const { Item: updatedItem } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
 
-    const { Item: updatedItem } = await documentClient
-      .get({
-        TableName: tableName,
-        Key: key,
-      })
-      .promise();
-
-    expect(updatedItem).toEqual({
-      ...item,
-      ...updateData,
+      expect(updatedItem).toEqual({
+        ...item,
+        ...updateData,
+        version: 1,
+      });
     });
-  });
-});
+
+    test('should increment the version number by 1 on subsequent updates', async () => {
+      const { tableName, dao } = context;
+      const updateData = { test: uuid(), newField: uuid(), version: 0 };
+      await dao.update(key, updateData);
+      await dao.update(key, { ...updateData, version: 1 });
+      await dao.update(key, { ...updateData, version: 2 });
+
+      const { Item: updatedItem } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
+
+      expect(updatedItem).toEqual({
+        ...item,
+        ...updateData,
+        version: 3,
+      });
+    });
+
+    test('should error if update does not supply the correct version number', async () => {
+      const { dao } = context;
+      const updateData = { test: uuid(), newField: uuid(), version: 0 };
+      // sets the initial version to 1
+      await dao.update(key, updateData);
+
+      await expect(async () => {
+        // doesn't supply a version, throws error
+        await dao.update(key, { test: 'new', status: 'value' });
+      }).rejects.toThrow('The conditional request failed');
+    });
+
+    test('should allow update without correct version number if ignore flag is set', async () => {
+      const { tableName, dao } = context;
+      const updateData = { test: uuid(), newField: uuid(), version: 0 };
+      // sets the initial version to 1
+      await dao.update(key, updateData);
+      // Still increments the version
+      await dao.update(key, updateData, {
+        ignoreOptimisticLocking: true,
+      });
+
+      const { Item: updatedItem } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
+
+      expect(updatedItem).toEqual({
+        ...item,
+        ...updateData,
+        version: 2,
+      });
+    });
+  }
+);


### PR DESCRIPTION
This will allow callers enhanced ability to decide how to adopt.

If optimistic locking gets turned on for a dao instance, there is an option to allow the specified `version` attribute to be created, even if a `put` or `update` does not specify it in the payload.  This option would require immediate adoption by all callers, as the first save will create and set `version` to 1.  Any subsequent updates/puts that do not supply the correct version attribute would fail.

If the dao instance is created with `autoInitiateLockingAttribute` set to `false`, the first call to `put` or `update` would not create the `version` attribute and any subsequent updates/puts would not fail, at least until `version` was supplied.  

This allows for adoption at the item-level, instead of at the dao instantiation.

# Example for dao-level adoption
First write adds version attribute which will then be enforced for any callers.  This is a similar flow to Amazon's Java SDK for Dynamo.

```
const dao = new DynamoDbDao<MyModel, MyKeySchema>({
  // table, client, etc.
  behavior: {
    optimisticLockingAttribute: 'version',
    autoInitiateLockingAttribute: true
  }
});
await dao.put({ id: 1, attr: 'test'});
await dao.get({ id: 1}); 
// returns {id: 1, attr: 'test', version: 1}
```

# Example for item-level adoption

This allows callers to adopt locking for the Dao, but wait to enable for any particular item until a caller explicitly sets it on an item
```
const dao = new DynamoDbDao<MyModel, MyKeySchema>({
  // table, client, etc.
  behavior: {
    optimisticLockingAttribute: 'version',
    autoInitiateLockingAttribute: false
  }
});
await dao.put({ id: 1, attr: 'test'});
await dao.get({ id: 1}); 
// returns {id: 1, attr: 'test'}
```