### PR TITLE
Fix bug in passing undefined version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export default class DynamoDbDao<DataModel, KeySchema> {
 
       // If the version attribute is supplied, increment it, otherwise only
       // set the default if directed to do so
-      if (versionAttribute in data) {
+      if (versionAttribute in data && !isNaN(dataAsMap[versionAttribute])) {
         dataAsMap[versionAttribute] += DEFAULT_LOCK_INCREMENT;
       } else if (this.autoInitiateLockingAttribute) {
         dataAsMap[versionAttribute] = DEFAULT_LOCK_INCREMENT;

--- a/src/update/generateUpdateParams.ts
+++ b/src/update/generateUpdateParams.ts
@@ -39,9 +39,11 @@ export function generateUpdateParams(
   } = options;
 
   let conditionExpression = options.conditionExpression;
+  const dataAsMap = data as DataModelAsMap;
 
   if (versionAttribute) {
-    const providesVersion = versionAttribute in data;
+    const providesVersion =
+      versionAttribute in data && !isNaN(dataAsMap[versionAttribute]);
 
     if (providesVersion || autoInitiateLockingAttribute) {
       addExpressions.push(`#${versionAttribute} :${versionAttribute}Inc`);
@@ -50,16 +52,15 @@ export function generateUpdateParams(
         versionInc ?? DEFAULT_LOCK_INCREMENT;
 
       if (!ignoreLocking) {
-        expressionAttributeValueMap[`:${versionAttribute}`] = (
-          data as DataModelAsMap
-        )[versionAttribute];
+        expressionAttributeValueMap[`:${versionAttribute}`] =
+          dataAsMap[versionAttribute];
       }
     }
 
     if (!ignoreLocking) {
       ({ conditionExpression } = buildOptimisticLockOptions({
         versionAttribute,
-        versionAttributeValue: (data as DataModelAsMap)[versionAttribute],
+        versionAttributeValue: dataAsMap[versionAttribute],
         conditionExpression,
       }));
     }

--- a/test/put.locking.test.ts
+++ b/test/put.locking.test.ts
@@ -43,6 +43,34 @@ describe.each([true, false])(
       });
     });
 
+    test('should / should not add version number on first put when version undefined', async () => {
+      const { tableName, dao } = context;
+
+      const key = { id: uuid() };
+
+      const input = {
+        ...key,
+        test: uuid(),
+        version: undefined,
+      };
+
+      // put data into dynamodb
+      await dao.put(input);
+
+      // ensure it exists
+      const { Item: item } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
+
+      expect(item).toEqual({
+        ...input,
+        version: autoInitiateLockingAttribute ? 1 : undefined,
+      });
+    });
+
     test('should throw error if version number is not supplied on second update', async () => {
       const { dao } = context;
 

--- a/test/update.locking.test.ts
+++ b/test/update.locking.test.ts
@@ -69,6 +69,25 @@ describe.each([true, false])(
       });
     });
 
+    test('should handle undefined version', async () => {
+      const { tableName, dao } = context;
+      const updateData = { test: uuid(), newField: uuid(), version: undefined };
+      await dao.update(key, updateData);
+
+      const { Item: updatedItem } = await documentClient
+        .get({
+          TableName: tableName,
+          Key: key,
+        })
+        .promise();
+
+      expect(updatedItem).toEqual({
+        ...item,
+        ...updateData,
+        version: autoInitiateLockingAttribute ? 1 : undefined,
+      });
+    });
+
     test('should set the version number on first update if supplied', async () => {
       const { tableName, dao } = context;
       const updateData = { test: uuid(), newField: uuid(), version: 0 };


### PR DESCRIPTION
This was causing a regression in some jupiter-settings-service test cases.